### PR TITLE
Alternative rebuild no osx X11 patch because no X11 conda package

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,22 +1,5 @@
 #!/bin/sh
 
-# OSX fix for X11 / tk 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # In the case of macOs include/X11 are the fake ones from tk
-  # which is needed due to other dependencies. However we have
-  # the good ones in the include folder of the host. So to let
-  # the compiler take the good ones, we alias the wrong header
-  # folder during compilation then restore it as it was.
-  # We can't use CMAKE_IGNORE_PATH as the include folder is used
-  # for other dependencies.
-  # This fix is inspired from @pkgw (https://github.com/pkgw) in
-  # https://github.com/conda-forge/tk-feedstock/pull/16 and adapted
-  # to take advantage of the presence of isolated X11 header in build
-  export X11_PATH=$PREFIX/include/X11
-  export X11_ALIAS_PATH=$PREFIX/include/tk_X11
-  mv $X11_PATH $X11_ALIAS_PATH
-fi
-
 mkdir build
 cd build
 cmake .. \
@@ -26,8 +9,3 @@ cmake .. \
       -DCMAKE_INSTALL_LIBDIR=lib
 make -j${CPU_COUNT} 
 make install
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # Restore the fix
-  mv $X11_ALIAS_PATH $X11_PATH
-fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/opengl_link.patch    
 
 build:
-  number: 8
+  number: 9
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin='x.x') }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
