### PR TITLE
Discard useless X11 option in qt5 and advice qt to use desktop OpenGL

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/no_x11_link.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   patches:
     - patches/qcontext_fix.patch
     - patches/no_x11_link.patch
+    - patches/qt_opengl_option.patch
 
 build:
   number: 1

--- a/recipe/patches/qt_opengl_option.patch
+++ b/recipe/patches/qt_opengl_option.patch
@@ -1,0 +1,26 @@
+From df58fc2f3b4a695c15e318a6a1d4142f07bb76c1 Mon Sep 17 00:00:00 2001
+From: yann_dm <yann.montmarin@gmail.com>
+Date: Mon, 9 Nov 2020 15:55:21 +0100
+Subject: [PATCH] Force qt external OpenGL for compatibility with MacOSX osgqt
+
+---
+ src/gui/main.cc.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git src/gui/main.cc.in src/gui/main.cc.in
+index 855a68b..97672f3 100644
+--- src/gui/main.cc.in
++++ src/gui/main.cc.in
+@@ -43,7 +43,8 @@ void setupApplication ()
+ 
+ int main(int argc, char *argv[])
+ {
+-  QApplication::setAttribute(Qt::AA_X11InitThreads);
++
++  QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+ 
+   SafeApplication a(argc, argv);
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
